### PR TITLE
doc: change appName to modalText

### DIFF
--- a/src/transport/qr.js
+++ b/src/transport/qr.js
@@ -7,15 +7,15 @@ const POLLING_INTERVAL = 2000
 /**
 *  A QR tranpsort which uses our provide QR modal to relay a request to a uport client
 *
-*  @param    {String}       appName  app name used in qr modal display
-*  @return   {Function}              a configured QRTransport Function
-*  @param    {String}       message  a uport client request message
-*  @return   {Function}              a function to close the QR modal
+*  @param    {String}       displayText   dialog used in qr modal display
+*  @return   {Function}                   a configured QRTransport Function
+*  @param    {String}       message       a uport client request message
+*  @return   {Function}                   a function to close the QR modal
 */
-const send = (appName) => (message, {cancel} = {}) => {
+const send = (displayText) => (message, {cancel} = {}) => {
   let uri = messageToURI(message)
   uri = /callback_type=/.test(uri) ? uri : paramsToQueryString(uri, {callback_type: 'post'})
-  open(uri, cancel, appName)
+  open(uri, cancel, displayText)
   return close
 }
 
@@ -30,8 +30,8 @@ const send = (appName) => (message, {cancel} = {}) => {
   *  @param    {String}       message          a uport client request message
   *  @return   {Promise<Object, Error>}        a function to close the QR modal
   */
-const chasquiSend = ({chasquiUrl = CHASQUI_URL, pollingInterval = POLLING_INTERVAL, appName } = {}) => {
-  const transport = URIHandlerSend(send(appName), {chasquiUrl, pollingInterval})
+const chasquiSend = ({ chasquiUrl = CHASQUI_URL, pollingInterval = POLLING_INTERVAL, displayText } = {}) => {
+  const transport = URIHandlerSend(send(displayText), {chasquiUrl, pollingInterval})
   return (message, params) => transport(message, params).then(res => {
     close()
     return res

--- a/src/transport/ui/index.js
+++ b/src/transport/ui/index.js
@@ -52,12 +52,11 @@ const makeModal = (content, closeModal = close) => {
  *
  *  @param    {String}     data       data which is displayed in QR code
  *  @param    {Function}   cancel     a function called when the cancel button is clicked
- *  @param    {String}     appName    name of the users app
- *  @param    {Boolean}    introModal a flag for displaying the intro
+ *  @param    {String}     modalText  message to be displayed above the QR in the modal
  */
-const open = (data, cancel, appName) => {
+const open = (data, cancel, modalText) => {
   const closeModal = close // closure over close for use in callbacks etc.
-  const content = qrModal(getImageDataURI(data), appName)
+  const content = qrModal(getImageDataURI(data), modalText)
 
   const cancelClick = (event) => {
     document.getElementById('uport__qr-text').innerHTML = 'Cancelling'

--- a/src/transport/ui/templates.js
+++ b/src/transport/ui/templates.js
@@ -1,13 +1,14 @@
 import SVG from './assets'
 import modalCSS from './style.css'
 
-const apppleStoreLink = 'https://itunes.apple.com/us/app/uport-id/id1123434510?mt=8'
+const appleStoreLink = 'https://itunes.apple.com/us/app/uport-id/id1123434510?mt=8'
 const googleStoreLink = 'https://play.google.com/store/apps/details?id=com.uportMobile'
 
 /**
- *  Modal skeleton
+ * Skeleton for a modal popup, styled with css imported from './style.css'
  *
- *  @param    {String}     innerHTML    content of modal
+ * @param    {String}   innerHTML    html string defining content of modal
+ * @returns  {String}   html string for the populated modal
  */
 export const uportModal = (innerHTML) => `
   <div id="uport__modal-bg">
@@ -25,20 +26,17 @@ export const uportModal = (innerHTML) => `
   </div>
 `
 
-// Helper for formatting 'Login to x' -- Currently not used, not sure what to do with it
-const loginText = (appName) => appName && appName !== 'uport-connect-app'
-  ? `<span>Login to </span><span style="${uportAppName}">${appName}</span>`
-  : `<span>Login</span>`
-
 /**
- *  The first content you will see in the modal
+ * Format a modal with a QR code and a custom message, as well as links to 
+ * the uport mobile app on the app store and play store
  *
- *  @param    {String}     appNamme  Name of users uPort App
- *  @return   {Object}     populated modal
+ *  @param    {String}    qrImageUri    data uri defining the QR code to be displayed
+ *  @param    {String}    modalText     message to be displayed above the QR code
+ *  @return   {Object}    populated modal
  */
-export const qrModal = (qrImageUri, message = "Login") => uportModal(`
+export const qrModal = (qrImageUri, modalText = '') => uportModal(`
   <div id="uport__modal-main">
-    <h2 id="uport__qr-text">${message}</h2>
+    <h2 id="uport__qr-text">${modalText}</h2>
     <div class="uport__modal-section">
       <img src="${qrImageUri}" />
       <p>Scan QR code with uPort Mobile App</p>
@@ -49,13 +47,14 @@ export const qrModal = (qrImageUri, message = "Login") => uportModal(`
     <p>Don't have uPort? Get it here!</p>
     <div>
       <a href="${googleStoreLink}" target="_blank"><img src="${SVG.androidApp}"/></a>
-      <a href="${apppleStoreLink}" target="_blank"><img src="${SVG.appleApp}"/></a>
+      <a href="${appleStoreLink}" target="_blank"><img src="${SVG.appleApp}"/></a>
     </div>
   </div>
 `)
 
 /**
- * Modal content for
+ * Html string for a modal notifying a user that a push notification has been
+ * sent to their phone
  */
 export const pushModal = uportModal(`
   <div id="uport__modal-main">
@@ -69,6 +68,9 @@ export const pushModal = uportModal(`
   </div>
 `)
 
+/**
+ * Html string for a modal displaying a success message
+ */
 export const successModal = uportModal(`
   <div id="uport__modal-main">
     <div class="uport__modal-section">
@@ -80,6 +82,10 @@ export const successModal = uportModal(`
   </div>
 `)
 
+/**
+ * Html string for a modal displaying a failure message
+ * !! Not used
+ */
 export const failureModal = uportModal(`
   <div id="uport__modal-main">
     <div class="uport__modal-section">


### PR DESCRIPTION
Updating some inline docs to better describe the `modalText` parameter passed to the QR modal.  Also changed default to empty string, and improved inline docs for other templates