### PR TITLE
feat: support deeplink and universal link URI schemes

### DIFF
--- a/src/message/util.js
+++ b/src/message/util.js
@@ -63,13 +63,24 @@ const getURLJWT = (url) => url.replace(/https:\/\/id.uport.me\/req\//, '').repla
 const isJWT = (jwt) => /^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]*)/.test(jwt)
 
 /**
-  * Given token request (JWT), wraps in request URI
-  *
-  *  @param    {String}       message       A request message (JWT), or if given URI will just return
-  *  @return   {Staring}                    A valid request URI, including the given request token
-  */
-const messageToURI = (message) =>  message.match('id.uport.me') ?  message : `https://id.uport.me/req/${message}`
+ * Wrap a JWT in a request URI using the Universal Link scheme based at id.uport.me
+ * @param    {String}       message       A request message (JWT), or if given URI will just return
+ * @return   {String}                    A valid request URI, including the given request token
+ */
+const messageToUniversalURI = (message) =>  message.match('id.uport.me') ?  message : `https://id.uport.me/req/${message}`
 
+/**
+ * Wrap a JWT in a request URI using the Deeplink scheme, using me.uport: 
+ * @param {String} message  A request message (JWT)
+ * @param {String} uri      The associated deeplink uri for the given message
+ */
+const messageToDeeplinkURI = (message) => message.match('me.uport:') ? message : `me.uport:req/${message}`
 
+/**
+ * Wrap a JWT in a request URI according to the specified scheme
+ * @param {String} message  The message to be uri encoded
+ * @param {String} type     The URI method of the above two, either 'universal' or 'deeplink'
+ */
+const messageToURI = (message, type='universal') => type === 'universal' ? messageToUniversalURI(message) : messageToDeeplinkURI(message)
 
-export { paramsToUrlFragment, paramsToQueryString, getUrlQueryParams, getURLJWT, isJWT, messageToURI }
+export { paramsToUrlFragment, paramsToQueryString, getUrlQueryParams, getURLJWT, isJWT, messageToURI, messageToUniversalURI, messageToDeeplinkURI }

--- a/src/transport/url.js
+++ b/src/transport/url.js
@@ -1,12 +1,13 @@
-import { paramsToQueryString, paramsToUrlFragment, messageToURI } from './../message/util.js'
+import { paramsToQueryString, paramsToUrlFragment, messageToURI as defaultMessageToURI } from './../message/util.js'
 import qs from 'qs'
 
 // TODO callback_url and redirect or just one
 /**
   *  A mobile transport for handling and configuring requests which are sent from a mobile browser to a uport client, in this case the uPort mobile app.
   *
-  *  @param    {Object}       [config={}]    an optional config object
-  *  @param    {String}       uriHandler     a function called with the requestURI once it is formatted for this transport, default opens URI
+  *  @param    {Object}      [config={}]             an optional config object
+  *  @param    {Function}    [config.messageToURI]   a function called with the message/JWT to format into a URI
+  *  @param    {Function}    [config.uriHandler]     a function called with the requestURI once it is formatted for this transport, default opens URI
   *  @return   {Function}                    a configured MobileTransport Function
   *  @param    {String}       message        a uport client request message
   *  @param    {Object}       [opts={}]      an optional config object
@@ -15,7 +16,7 @@ import qs from 'qs'
   *  @param    {String}       opts.type      specifies callback type 'post' or 'redirect' for response
   *  @param    {String}       opts.callback  specifies url which a uport client will return to control once request is handled, depending on request type it may or may not be returned with the response as well.
   */
-const send = ({uriHandler}={}) => {
+const send = ({uriHandler, messageToURI=defaultMessageToURI}={}) => {
   return (message, {id, data, type, redirectUrl} = {}) => {
     let uri = messageToURI(message)
     if (type) uri = paramsToQueryString(uri, {callback_type: type})


### PR DESCRIPTION
Add two functions to `message.util`: `messageToUniversalURI()` and `messageToDeeplinkURI`.  Add second parameter `type` to `message.util.messageToURI` to switch between the above two methods. 

Allow `transport.url.send` to take a custom `messageToURI` function, defaulting to `message.util.messageToURI`.

This should make it easier to switch between URI schemes in the future, and support hybrid schemes.

Blocker for uport-project/uport-connect#214