### PR TITLE
fix: Separate url arguments in chasqui compression payload

### DIFF
--- a/src/transport/qr.js
+++ b/src/transport/qr.js
@@ -1,29 +1,29 @@
 import nets from 'nets'
 
 import { open, close, success, failure } from './ui'
-import { paramsToQueryString, messageToURI } from './../message/util.js'
+import { paramsToQueryString, messageToURI, getUrlQueryParams } from './../message/util.js'
 import { URIHandlerSend, CHASQUI_URL, genCallback } from './messageServer'
 
 const POLLING_INTERVAL = 2000
 
 /**
- *  A QR tranpsort which uses our provided QR modal to relay a request to a uPort client
+ * A QR tranpsort which uses our provided QR modal to relay a request to a uPort client,
+ * optionally compressing the provided message if a compress function is provided
  *
- *  @param    {String}       displayText   dialog used in qr modal display
- *  @return   {Function}                   a configured QRTransport Function
- *    @param    {String}       message            a uport client request message
- *    @param    {Object}       [opts={}]
- *    @param    {Function}     [opts.cancel]      cancel callback, called on modal close
- *    @param    {Function}     [opts.compress]    a function to compress a JWT, returning a promise that resolves to a string 
- *    @return   {Function}                        a function to close the QR modal
+ * @param    {String}       displayText   dialog used in qr modal display
+ * @return   {Function}                   a configured QRTransport Function
+ *   @param    {String}       message            a uport client request message
+ *   @param    {Object}       [opts={}]
+ *   @param    {Function}     [opts.cancel]      cancel callback, called on modal close
+ *   @param    {Function}     [opts.compress]    a function to compress a JWT, returning a promise that resolves to a string 
+ *   @return   {Function}                        a function to close the QR modal
  */
 const send = (displayText) => (message, {cancel, compress} = {}) => {
   if (compress) {
     compress(message).then((msg) => {
-      let uri = messageToURI(msg)
-      uri = /callback_type=/.test(uri) ? uri : paramsToQueryString(uri, {callback_type: 'post'})
-      open(uri, cancel, displayText)
+      open(msg, cancel, displayText)
     }).catch((err) => {
+      console.error(err)
       // Display failure modal and allow retry
       failure(() => send(displayText)(message, {cancel, compress}))
     })
@@ -52,13 +52,20 @@ const send = (displayText) => (message, {cancel, compress} = {}) => {
 const chasquiCompress = (message, threshold=650) => {
   return new Promise((resolve, reject) => {
     if (message.length < threshold) {
-      resolve(message)
+      let uri = messageToURI(message)
+      uri = /callback_type=/.test(uri) ? uri : paramsToQueryString(uri, {callback_type: 'post'})
+      resolve(uri)
       return 
+    }
+    // Trim message and extract query params
+    const topic = {
+      message: message.replace(/\?.*/, ''),
+      ...getUrlQueryParams(message) 
     }
     nets({
       uri: `${CHASQUI_URL}topic/`,
       method: 'POST',
-      body: JSON.stringify({message}),
+      body: JSON.stringify(topic),
       headers: {
         'content-type': 'application/json'
       },

--- a/src/transport/qr.js
+++ b/src/transport/qr.js
@@ -58,14 +58,16 @@ const chasquiCompress = (message, threshold=650) => {
     nets({
       uri: `${CHASQUI_URL}topic/`,
       method: 'POST',
-      body: {'request': message},
+      body: JSON.stringify({message}),
       headers: {
         'content-type': 'application/json'
-      }
+      },
+      withCredentials: false,
+      rejectUnauthorized: false
     }, function (err, response) {
       if (err) reject(err)
-      if (response.statusCode !== 201) reject('Failed to create topic')
-      resolve(encodeURI(response.headers.Location))      
+      else if (response.statusCode !== 201) reject('Failed to create topic')
+      else resolve(response.headers.location || response.headers.Location)      
     })
   })
 }

--- a/test/transport/qr.js
+++ b/test/transport/qr.js
@@ -1,10 +1,9 @@
 const proxyquire = require('proxyquire')
 const chai = require('chai')
 const sinon = require('sinon')
+const { messageToURI } = require('../../src/message/util')
 const expect = chai.expect
 chai.use(require('sinon-chai'))
-
-const { isMessageServerCallback } = require('../../src/transport/messageServer')
 
 // Exactly 650 characters
 const fakeJWT = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiY2xhaW0iOiJsYWxhbGFsYWxhbGFsYWxhbGFsYWxhbGFsYWxhbGFsYWxhbGFsYWxhbGFsYWxsYWxhbGFsYWxhbGFsYWxhbGFsYWxhbGFzZmphbGtmandvZWZqcGFvaXdqZnBramF3ZWZwb2lqZmVyaW9mam9pYXdqZmVvamFvc2lmam9haWVqZm9pYXdlam9maWphb2lzZWpmb2lhc2plZm9pYWpwb3dldWhmcWxsa2MsZG0sZG1kbWRtYXNtYSx3Zml3ZWYzMHN3ZWY0dDk4dTg0aGcwM3VoNGcwaXUzaGdmMG9pcnVuMDR1cm9mbHF1NDU5aG9xODV1NTA5ODN1NDA5ODIzdTR0b2lqZmxpamloYXNmZWFmZmVmZWVlZWVhc2V5dWllamZpZWplbGZpM2pmOTgzamY5MnVqa3NyZGZsaWoifQ.pcofwu5zy5i7SAQpCCa5kIAFMtsSSrSyLD8QG_Mkrh-Xjfo8U9xdB5u2575wCiFUHUG2GXWKM4DBM6yIZQVlLA'
@@ -24,7 +23,7 @@ describe('qr send', () => {
 })
 
 describe('chasquiCompress', () => {
-  it('does nothing for messages below the threshold', () => {
+  it('formats messages below the threshold as uris', () => {
     const message = 'shortmessage'
     const nets = sinon.spy()
     const { chasquiCompress } = proxyquire('../../src/transport/qr', {
@@ -32,22 +31,31 @@ describe('chasquiCompress', () => {
     })
 
     return chasquiCompress(message).then((msg) => {
-      expect(msg).to.equal(message)
+      expect(msg).to.equal(messageToURI(message) + '?callback_type=post')
       expect(nets).to.not.be.called
     })
   })
 
   it('uploads to chasqui for long messages, and returns an encoded topicUrl', () => {
-    const threshold = 650
-    const nets = sinon.stub().callsFake((_, cb) => cb(null, {
-      statusCode: 201,
-      headers: {Location: '/topic/deadbeefDEADBEEF'}
-    }))
+    const callback_type = 'post'
+    const callback_url = 'uport.me'
+    const message = `${fakeJWT}?callback_url=${callback_url}&callback_type=${callback_type}`;
+
+    const nets = sinon.stub().callsFake(({body}, cb) => {
+      body = JSON.parse(body)
+      expect(body.message).to.equal(fakeJWT)
+      expect(body.callback_type).to.equal(callback_type)
+      expect(body.callback_url).to.equal(callback_url)
+      cb(null, {
+        statusCode: 201,
+        headers: {Location: '/topic/deadbeefDEADBEEF'}
+      })
+    })
     const { chasquiCompress } = proxyquire('../../src/transport/qr', {
       'nets': nets
     })
 
-    return chasquiCompress(fakeJWT).then((msg) => {
+    return chasquiCompress(message).then((msg) => {
       expect(decodeURI(msg)).to.match(/\/topic\//)
       expect(nets).to.be.calledOnce
     })


### PR DESCRIPTION
Simple fix, should work with current and `develop` version of lambda-chasqui