### PR TITLE
feat: add 'typedDataSig' as a messageParse option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-transports",
-  "version": "0.2.0-alpha.0",
+  "version": "0.2.0-alpha.1",
   "description": "Set up communication channels between your app and a uPort client to handle requests and responses",
   "main": "lib/index.js",
   "scripts": {

--- a/src/transport/messageServer.js
+++ b/src/transport/messageServer.js
@@ -47,7 +47,7 @@ const URIHandlerSend = (uriHandler, {messageServerUrl = CHASQUI_URL, pollingInte
   *  @return   {Promise<Object, Error>}                     a promise which resolves with obj/message or rejects with an error
   */
 const poll = (url, pollingInterval, cancelled ) => {
-  const messageParse = (res) => { if (res.message) return res.message['access_token'] || res.message['tx'] }
+  const messageParse = (res) => { if (res.message) return res.message['access_token'] || res.message['tx'] || res.message['typedDataSig'] }
   const errorParse = (res) => { if (res.message) return res.message.error }
   return generalPoll(url, messageParse, errorParse, cancelled, pollingInterval).then(res => {
     clearResponse(url)

--- a/src/transport/url.js
+++ b/src/transport/url.js
@@ -72,9 +72,10 @@ const parseResponse = (url) => {
   if (params.id) {
     const response = { data: params.data || null,  id: params.id}
     if (params.error) return Object.assign(response, {error: params.error, payload: null})
-    if (params['access_token']) return Object.assign(response, {payload: params['access_token']})
-    if (params['verification']) return Object.assign(response, {payload: params['verification']})
-    if (params['tx'])           return Object.assign(response, {payload: params['tx']})
+    if (params['access_token'])  return Object.assign(response, {payload: params['access_token']})
+    if (params['verification'])  return Object.assign(response, {payload: params['verification']})
+    if (params['typedDataSign']) return Object.assign(response, {payload: params['typedDataSig']})
+    if (params['tx'])            return Object.assign(response, {payload: params['tx']})
     return Object.assign(response, {payload: null})
   }
   return null

--- a/src/transport/url.js
+++ b/src/transport/url.js
@@ -74,7 +74,7 @@ const parseResponse = (url) => {
     if (params.error) return Object.assign(response, {error: params.error, payload: null})
     if (params['access_token'])  return Object.assign(response, {payload: params['access_token']})
     if (params['verification'])  return Object.assign(response, {payload: params['verification']})
-    if (params['typedDataSign']) return Object.assign(response, {payload: params['typedDataSig']})
+    if (params['typedDataSig']) return Object.assign(response, {payload: params['typedDataSig']})
     if (params['tx'])            return Object.assign(response, {payload: params['tx']})
     return Object.assign(response, {payload: null})
   }


### PR DESCRIPTION
This should allow the signTypedData responses to get handled by transports and passed to the libraries.

NOTE: this is terrible, we definitely need to figure out more elegant ways of handling the different types of responses as it's already unruly and will only get worse

@mi-xu @aldigjo We should figure out some common way of negotiating communication standards between the mobile app and the libraries.  Perhaps we could factor both these keys and the request `'types'` into a `uport-messages` library or something, which is mostly just a set of constants and maybe utility functions that can be imported by both the mobile app and libs.  That way we don't have to have ugly garbage in either that can easily get out of sync.

(cc @jasonhealy)