### PR TITLE
fix: use 'in' to test object membership rather than value's truthiness

### DIFF
--- a/src/transport/messageServer.js
+++ b/src/transport/messageServer.js
@@ -52,7 +52,7 @@ const URIHandlerSend = (uriHandler, { messageServerUrl = CHASQUI_URL, pollingInt
 const poll = (url, pollingInterval, cancelled) => {
   const messageParse = res => {
     // Support new and old chasqui format
-    const message = res.message && (res.message.content ? JSON.parse(res.message.content) : res.message)
+    const message = res.message && (('content' in res.message) ? JSON.parse(res.message.content) : res.message)
     // FIXME: this is not a great method for handling our expected keys in the response.
     //        Very tightly coupled to the message format, and these keys seem to come out
     //        of nowhere.


### PR DESCRIPTION
One line changed, detect new Chasqui format with 
```javascript
if ('content' in res.message)
```
rather than 
```javascript
if (res.message.content)
```